### PR TITLE
bug: don't panic if default node can't be located

### DIFF
--- a/src/wpctl/node.rs
+++ b/src/wpctl/node.rs
@@ -302,7 +302,7 @@ pub fn show_defaults(prefer_gui: bool) {
     inform(joined.as_str(), prefer_gui);
 }
 
-pub fn get_default_node(node_type_str: String) -> String {
+pub fn get_default_node(node_type_str: String) -> Option<String> {
     let node_type = NodeType::from_str(&node_type_str).unwrap();
     let status = get_status();
     let nodes = match node_type {
@@ -313,5 +313,8 @@ pub fn get_default_node(node_type_str: String) -> String {
             &status.sources
         }
     };
-    default_node(nodes).unwrap().name.clone()
+    if let Some(node) = default_node(nodes) {
+        return Some(node.name.clone());
+    }
+    None
 }

--- a/src/wpctl/volume.rs
+++ b/src/wpctl/volume.rs
@@ -153,7 +153,13 @@ mod tests {
 
 fn notify(volume: f32, node_type: &NodeType) {
     let node = get_default_node(node_type_to_str(node_type));
-    let truncated = truncate_node_name(node);
+    if node.is_none() {
+        notify::message(
+            format!("Cannot determine default {}", node_type_to_str(node_type)).as_str(),
+        );
+        return;
+    }
+    let truncated = truncate_node_name(node.unwrap());
     notify::volume(volume, truncated);
 }
 


### PR DESCRIPTION
This seems to be an issue if no microphone is plugged in.
