### PR TITLE
display current node type by emojis in notification

### DIFF
--- a/src/wpctl/volume.rs
+++ b/src/wpctl/volume.rs
@@ -160,6 +160,12 @@ fn notify(volume: f32, node_type: &NodeType) {
         return;
     }
     let truncated = truncate_node_name(node.unwrap());
+    let prefix = match node_type {
+        NodeType::Sink => {"🔈"}
+        NodeType::Source => {"🎤"}
+    };
+    let node = format!("{prefix} {truncated}");
+    let truncated = truncate_node_name(node);
     notify::volume(volume, truncated);
 }
 


### PR DESCRIPTION
Being able to easily tell what type of the node belongs to is useful if the sink and source for the
same device have the same names.
