### PR TITLE
use the notification icon for differentiating nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "nor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nor"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/src/notify/mod.rs
+++ b/src/notify/mod.rs
@@ -1,8 +1,9 @@
 use ::notify_rust::{Hint, Notification, Urgency};
+use crate::NodeType;
 
 const NOTIFICATION_SUMMARY: &str = "nor";
 
-fn get_volume_classifier(volume: f32) -> String {
+fn get_volume_classifier(volume: f32, node_type: &NodeType) -> String {
     let vol = if volume == 0.0 {
         "muted"
     } else if volume <= 0.3 {
@@ -12,14 +13,22 @@ fn get_volume_classifier(volume: f32) -> String {
     } else if volume <= 1.0 {
         "high"
     } else {
-        "overamplified"
+        if let NodeType::Sink = node_type {
+            "overamplified"
+        } else {
+            "high"
+        }
     };
     vol.to_string()
 }
 
-fn get_icon(volume: f32) -> String {
-    let classifier = get_volume_classifier(volume);
-    format!("audio-volume-{}-symbolic", classifier)
+fn get_icon(volume: f32, node_type: &NodeType) -> String {
+    let prefix = match node_type {
+        NodeType::Sink => {"audio-volume"}
+        NodeType::Source => {"microphone-sensitivity"}
+    };
+    let classifier = get_volume_classifier(volume, node_type);
+    format!("{prefix}-{classifier}-symbolic")
 }
 
 pub fn message(msg: &str) {
@@ -30,8 +39,8 @@ pub fn message(msg: &str) {
         .expect("error sending notification");
 }
 
-pub fn volume(volume: f32, node_name: String) {
-    let icon = get_icon(volume);
+pub fn volume(volume: f32, node_name: String, node_type: &NodeType) {
+    let icon = get_icon(volume, node_type);
     let vol_scaled = volume * 100.0;
     let vol_int = vol_scaled.round() as u32;
 

--- a/src/wpctl/volume.rs
+++ b/src/wpctl/volume.rs
@@ -160,13 +160,7 @@ fn notify(volume: f32, node_type: &NodeType) {
         return;
     }
     let truncated = truncate_node_name(node.unwrap());
-    let prefix = match node_type {
-        NodeType::Sink => {"🔈"}
-        NodeType::Source => {"🎤"}
-    };
-    let node = format!("{prefix} {truncated}");
-    let truncated = truncate_node_name(node);
-    notify::volume(volume, truncated);
+    notify::volume(volume, truncated, node_type);
 }
 
 pub fn apply(change: VolumeOp) {


### PR DESCRIPTION
Use the notification icon instead of emojis to display if the volume change affects a sink or source.
